### PR TITLE
TASK-5354 CI propertyPath: nginx.image.tag → image.tag

### DIFF
--- a/.github/workflows/build-codap-dev.yml
+++ b/.github/workflows/build-codap-dev.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       env: dev
       target: develop
-      propertyPath: nginx.image.tag
+      propertyPath: image.tag
       updateTargets: |
         {
           "aws": {

--- a/.github/workflows/build-codap-prd.yml
+++ b/.github/workflows/build-codap-prd.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       env: prd
       target: main
-      propertyPath: nginx.image.tag
+      propertyPath: image.tag
       updateTargets: |
         {
           "aws": {


### PR DESCRIPTION
## Summary
- codap-nginx 차트가 bitnami 서브차트에서 자체 템플릿으로 전환됨에 따라 values 구조가 `nginx.image.tag` → `image.tag`로 변경
- CI 워크플로우의 `propertyPath`를 일치하도록 수정

## Test plan
- [ ] jce-service-helm 차트 리팩토링 PR 머지 후 develop push 시 image tag 자동 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)