### PR TITLE
INF-279 CI/CD NCloud CR push 제거

### DIFF
--- a/.github/workflows/build-codap-dev.yml
+++ b/.github/workflows/build-codap-dev.yml
@@ -17,15 +17,8 @@ jobs:
           "aws": {
             "imageName": "jce-ecr-codap-all-dev",
             "valueFilePath": ["codap-nginx/aws-apne2-dev-service.yaml"]
-          },
-          "ncp": {
-            "registry": "ped-cr-all-dev.ncr.gov-ntruss.com",
-            "imageName": "jce-codap",
-            "valueFilePath": ["codap-nginx/ncloud.yaml"]
           }
         }
 
     secrets:
-      NCP_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY_ID }}
-      NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
       MACHINE_TOKEN: ${{ secrets.MACHINE_TOKEN }}

--- a/.github/workflows/build-codap-prd.yml
+++ b/.github/workflows/build-codap-prd.yml
@@ -17,15 +17,8 @@ jobs:
           "aws": {
             "imageName": "jce-ecr-codap-all-prd",
             "valueFilePath": ["codap-nginx/aws-apne2-prd-service.yaml"]
-          },
-          "ncp": {
-            "registry": "ped-cr-all-prd.ncr.gov-ntruss.com",
-            "imageName": "jce-codap",
-            "valueFilePath": ["codap-nginx/ncloud-prd.yaml"]
           }
         }
 
     secrets:
-      NCP_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY_ID }}
-      NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
       MACHINE_TOKEN: ${{ secrets.MACHINE_TOKEN }}


### PR DESCRIPTION
# 요구 사항

- INF-279 각 레포 CI/CD에서 NCloud Container Registry push step 제거

# 변경 사항

- build 워크플로우의 `updateTargets`에서 `ncp` 타겟 제거
- 미사용 `NCP_ACCESS_KEY_ID` / `NCP_SECRET_KEY` secrets 제거
- AWS ECR push 및 helm 이미지 태그 갱신은 그대로 유지

NCP -> AWS 이전이 완료된 서비스로, prd NCP에 활성 ingress가 없어 트래픽은 이미 AWS로 이전된 상태다.
